### PR TITLE
Fix luarocks config for cmake

### DIFF
--- a/rockspecs/luacrypto-git-1.rockspec
+++ b/rockspecs/luacrypto-git-1.rockspec
@@ -11,7 +11,7 @@ dependencies = {
 	"lua >= 5.1",
 }
 source = {
-	url = [[git://github.com/mkottman/luacrypto.git]],
+	url = [[git://github.com/evanlabs/luacrypto.git]],
 	dir = "luacrypto"
 }
 build = {
@@ -22,7 +22,7 @@ build = {
 			install_command = [[copy ".\Release\crypto.dll" "$(LIBDIR)\crypto.dll" /y ]]
 		},
 		unix = {
-			type = "make",
+			type = "cmake",
 			variables = {
 				INCONCERT_DEVEL = "$(INCONCERT_DEVEL)",
 				LUA_LUADIR = "$(LUADIR)",


### PR DESCRIPTION
Currently, luarocks install lapis breaks on Arch due to the OpenSSL upgrade breaking luarocks' luacrypto version. This version of luacrypto builds - so it would be great to get this on luarocks. This patch makes it build again using the luarocks buildsystem, so it's a step in that direction